### PR TITLE
Typo fix

### DIFF
--- a/src/command/restart.rs
+++ b/src/command/restart.rs
@@ -25,7 +25,7 @@ pub fn command(shards: u32) -> Command {
         )
         .option(BooleanBuilder::new(
             "resume",
-            "Resume ression? [default: false]",
+            "Resume session? [default: false]",
         ))
         .build()
 }


### PR DESCRIPTION
Just a quick typo fix to change `ression` to `session`. Logic is fine!