### PR TITLE
resume: dispatch iterators via Either

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 dashmap = "6"
+either = "1"
 rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,15 +19,11 @@ impl Context {
     }
 }
 
-pub fn init(
-    application_id: Id<ApplicationMarker>,
-    http: Client,
-    shards: DashMap<u32, ShardHandle>,
-) {
+pub fn init(application_id: Id<ApplicationMarker>, http: Client, shards: u32) {
     let context = Context {
         application_id,
         http,
-        shards,
+        shards: DashMap::with_capacity(shards as usize),
     };
     assert!(CTX.0.set(context).is_ok());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ pub use self::{
 };
 
 use anyhow::Context as _;
-use dashmap::DashMap;
 use std::{env, pin::pin, time::Duration};
 use tokio::signal;
 use tracing::{Instrument as _, instrument::Instrumented};
@@ -48,14 +47,13 @@ async fn main() -> anyhow::Result<()> {
     let config = ConfigBuilder::new(token, INTENTS).queue(queue).build();
     let shards = resume::restore(config, info.shards).await;
 
-    context::init(app.id, http, DashMap::with_capacity(shards.len()));
+    context::init(app.id, http, shards.len() as u32);
 
     command::register().await.context("registering commands")?;
 
     let tasks = shards
-        .into_iter()
         .map(|shard| tokio::spawn(dispatch::run(event_handler, shard, |_shard| ())))
-        .collect::<Vec<_>>();
+        .collect::<Box<[_]>>();
 
     signal::ctrl_c().await?;
     tracing::info!("shutting down; press CTRL-C to abort");

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use serde::{Deserialize, Serialize};
 use std::iter;
 use tokio::fs;
@@ -55,35 +56,36 @@ pub async fn save(info: &[Info]) -> anyhow::Result<()> {
 }
 
 /// Restores shard resumption information from the file system.
-pub async fn restore(config: Config, recommended_shards: u32) -> Vec<Shard> {
+pub async fn restore(
+    config: Config,
+    recommended_shards: u32,
+) -> impl ExactSizeIterator<Item = Shard> {
     let info = async {
         let contents = fs::read(INFO_FILE).await?;
-        anyhow::Ok(serde_json::from_slice::<Vec<Info>>(&contents)?)
+        anyhow::Ok(serde_json::from_slice::<Box<[_]>>(&contents)?)
     }
     .await;
 
     // The recommended shard count targets 1000 guilds per shard (out of a maximum
     // of 2500), so it might be different from the previous shard count.
-    let shards = if let Ok(info) = info
+    let configs = if let Ok(info) = info
         && recommended_shards / 2 <= info.len() as u32
     {
         tracing::info!("resuming previous gateway sessions");
-        let configs = iter::repeat_n(config, info.len())
-            .zip(info)
-            .map(|(config, info)| ConfigBuilder::from(config).resume_info(info).build());
-        shards(configs).collect()
+        Either::Left(
+            iter::repeat_n(config, info.len())
+                .zip(info)
+                .map(|(config, info)| ConfigBuilder::from(config).resume_info(info).build()),
+        )
     } else {
-        shards(iter::repeat_n(config, recommended_shards as usize)).collect()
+        Either::Right(iter::repeat_n(config, recommended_shards as usize))
     };
 
     // Resumed or not, the saved resume info is now stale.
     _ = fs::remove_file(INFO_FILE).await;
 
-    shards
-}
-
-fn shards(iter: impl ExactSizeIterator<Item = Config>) -> impl ExactSizeIterator<Item = Shard> {
-    let total = iter.len() as u32;
-    iter.zip((0..total).map(move |id| ShardId::new(id, total)))
+    let total = configs.len() as u32;
+    configs
+        .zip((0..total).map(move |id| ShardId::new(id, total)))
         .map(|(config, shard_id)| Shard::with_config(shard_id, config))
 }


### PR DESCRIPTION
Restore awkwardly worked around its different iterator types through generics (internally) and consuming the iterator (return value). Dispatching on a concrete type saves us from needlessly consuming the iterator and having to use generics.

This PR adds a dependency to the `either` crate and dispatches on it for restore's iterators. It also prefers `Box<[T]>` to `Vec<T>` where applicable and moves `DashMap` to an internal context module type.