### PR TITLE
add non-async main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "signal"] }
+tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ either = "1"
 rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["fs", "macros", "rt", "signal"] }
+tokio = { version = "1", features = ["macros", "rt", "signal"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,11 @@ pub use self::{
 
 use anyhow::Context as _;
 use std::{env, pin::pin, time::Duration};
-use tokio::signal;
+use tokio::{runtime::Builder as RuntimeBuilder, signal};
 use tracing::{Instrument as _, instrument::Instrumented};
-use twilight_gateway::{ConfigBuilder, Event, EventTypeFlags, Intents, queue::InMemoryQueue};
+use twilight_gateway::{
+    ConfigBuilder, Event, EventTypeFlags, Intents, Shard, queue::InMemoryQueue,
+};
 use twilight_http::Client;
 use twilight_model::id::{Id, marker::GuildMarker};
 
@@ -22,18 +24,20 @@ const ADMIN_GUILD_ID: Id<GuildMarker> = Id::new({{admin_guild_id}});
 const EVENT_TYPES: EventTypeFlags = EventTypeFlags::INTERACTION_CREATE;
 const INTENTS: Intents = Intents::empty();
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let token = env::var("TOKEN").context("reading `TOKEN`")?;
 
+    let rt = RuntimeBuilder::new_current_thread().enable_all().build()?;
+    let _guard = rt.enter();
+
     let http = Client::new(token.clone());
-    let app = async { anyhow::Ok(http.current_user_application().await?.model().await?) }
-        .await
+    let app = rt
+        .block_on(async { anyhow::Ok(http.current_user_application().await?.model().await?) })
         .context("getting app")?;
-    let info = async { anyhow::Ok(http.gateway().authed().await?.model().await?) }
-        .await
+    let info = rt
+        .block_on(async { anyhow::Ok(http.gateway().authed().await?.model().await?) })
         .context("getting info")?;
 
     // The queue defaults are static and may be incorrect for large or newly
@@ -45,10 +49,18 @@ async fn main() -> anyhow::Result<()> {
         info.session_start_limit.total,
     );
     let config = ConfigBuilder::new(token, INTENTS).queue(queue).build();
-    let shards = resume::restore(config, info.shards).await;
+    let shards = resume::restore(config, info.shards);
 
     context::init(app.id, http, shards.len() as u32);
 
+    let resume_info = rt.block_on(event_loop(shards))?;
+
+    resume::save(&resume_info).context("saving resume info")?;
+
+    Ok(())
+}
+
+async fn event_loop(shards: impl Iterator<Item = Shard>) -> anyhow::Result<Vec<ResumeInfo>> {
     command::register().await.context("registering commands")?;
 
     let tasks = shards
@@ -65,17 +77,10 @@ async fn main() -> anyhow::Result<()> {
         }
         anyhow::Ok(resume_info)
     };
-    let resume_info = tokio::select! {
-        _ = signal::ctrl_c() => Vec::new(),
-        resume_info = join_all_tasks => resume_info?,
-    };
-
-    // Save shard information to be restored.
-    resume::save(&resume_info)
-        .await
-        .context("saving resume info")?;
-
-    Ok(())
+    tokio::select! {
+        _ = signal::ctrl_c() => Ok(Vec::new()),
+        resume_info = join_all_tasks => resume_info,
+    }
 }
 
 async fn event_handler(event: Event, _state: ()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,9 @@ pub use self::{
 };
 
 use anyhow::Context as _;
-use std::{env, pin::pin, time::Duration};
+use std::{convert::identity, env, pin::pin, time::Duration};
 use tokio::{runtime::Builder as RuntimeBuilder, signal};
+use tokio_stream::StreamExt as _;
 use tracing::{Instrument as _, instrument::Instrumented};
 use twilight_gateway::{
     ConfigBuilder, Event, EventTypeFlags, Intents, Shard, queue::InMemoryQueue,
@@ -60,7 +61,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn event_loop(shards: impl Iterator<Item = Shard>) -> anyhow::Result<Vec<ResumeInfo>> {
+async fn event_loop(shards: impl Iterator<Item = Shard>) -> anyhow::Result<Box<[ResumeInfo]>> {
     command::register().await.context("registering commands")?;
 
     let tasks = shards
@@ -70,16 +71,10 @@ async fn event_loop(shards: impl Iterator<Item = Shard>) -> anyhow::Result<Vec<R
     signal::ctrl_c().await?;
     tracing::info!("shutting down; press CTRL-C to abort");
 
-    let join_all_tasks = async {
-        let mut resume_info = Vec::with_capacity(tasks.len());
-        for task in tasks {
-            resume_info.push(task.await?);
-        }
-        anyhow::Ok(resume_info)
-    };
+    let results = tokio_stream::iter(tasks).then(identity);
     tokio::select! {
-        _ = signal::ctrl_c() => Ok(Vec::new()),
-        resume_info = join_all_tasks => resume_info,
+        _ = signal::ctrl_c() => Ok(Box::default()),
+        resume_info = results.collect::<Result<_, _>>() => anyhow::Ok(resume_info?),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn event_loop(shards: impl Iterator<Item = Shard>) -> anyhow::Result<Box<[
 
     let tasks = shards
         .map(|shard| tokio::spawn(dispatch::run(event_handler, shard, |_shard| ())))
-        .collect::<Box<[_]>>();
+        .collect::<Box<_>>();
 
     signal::ctrl_c().await?;
     tracing::info!("shutting down; press CTRL-C to abort");

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -56,14 +56,10 @@ pub fn save(info: &[Info]) -> anyhow::Result<()> {
 
 /// Restores shard resumption information from the file system.
 pub fn restore(config: Config, recommended_shards: u32) -> impl ExactSizeIterator<Item = Shard> {
-    let info = (|| {
-        let contents = fs::read(INFO_FILE)?;
-        anyhow::Ok(serde_json::from_slice::<Box<[_]>>(&contents)?)
-    })();
-
     // The recommended shard count targets 1000 guilds per shard (out of a maximum
     // of 2500), so it might be different from the previous shard count.
-    let configs = if let Ok(info) = info
+    let configs = if let Ok(contents) = fs::read(INFO_FILE)
+        && let Ok(info) = serde_json::from_slice::<Box<[_]>>(&contents)
         && recommended_shards / 2 <= info.len() as u32
     {
         tracing::info!("resuming previous gateway sessions");

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1,7 +1,6 @@
 use either::Either;
 use serde::{Deserialize, Serialize};
-use std::iter;
-use tokio::fs;
+use std::{fs, iter};
 use twilight_gateway::{Config, ConfigBuilder, Session, Shard, ShardId};
 
 const INFO_FILE: &str = "resume-info.json";
@@ -46,25 +45,21 @@ impl From<&Shard> for Info {
 }
 
 /// Saves shard resumption information to the file system.
-pub async fn save(info: &[Info]) -> anyhow::Result<()> {
+pub fn save(info: &[Info]) -> anyhow::Result<()> {
     if !info.iter().all(Info::is_none) {
         let contents = serde_json::to_vec(&info)?;
-        fs::write(INFO_FILE, contents).await?;
+        fs::write(INFO_FILE, contents)?;
     }
 
     Ok(())
 }
 
 /// Restores shard resumption information from the file system.
-pub async fn restore(
-    config: Config,
-    recommended_shards: u32,
-) -> impl ExactSizeIterator<Item = Shard> {
-    let info = async {
-        let contents = fs::read(INFO_FILE).await?;
+pub fn restore(config: Config, recommended_shards: u32) -> impl ExactSizeIterator<Item = Shard> {
+    let info = (|| {
+        let contents = fs::read(INFO_FILE)?;
         anyhow::Ok(serde_json::from_slice::<Box<[_]>>(&contents)?)
-    }
-    .await;
+    })();
 
     // The recommended shard count targets 1000 guilds per shard (out of a maximum
     // of 2500), so it might be different from the previous shard count.
@@ -82,7 +77,7 @@ pub async fn restore(
     };
 
     // Resumed or not, the saved resume info is now stale.
-    _ = fs::remove_file(INFO_FILE).await;
+    _ = fs::remove_file(INFO_FILE);
 
     let total = configs.len() as u32;
     configs


### PR DESCRIPTION
The `tokio::fs` dependency is not necessary as it is only used during startup and shutdown (where it is fine to block). To not accidentally block the runtime, `event-loop` is split off into its own async function and `main` is made synchronous (where it is okay to block).

The binary size is reduced by 48 KiB (-0.5 %)